### PR TITLE
chore(cleanup): client/components architecture-aligned cleanup

### DIFF
--- a/.github/weekly-cleanup/cleanup-history.md
+++ b/.github/weekly-cleanup/cleanup-history.md
@@ -34,3 +34,8 @@ Entries are appended by the cleanup agent after each run. Do not hand-edit.
 
 ## 2026-05-25 (run-auto-cleanup) — libraries/repository/core
 - (no safe targets found) — focus module contains only interface definitions and extension syntax; no test files (tested via integration in dynamo/compound modules); all public APIs verified in-use
+
+## 2026-06-08 (run-27156507882-1) — client/components
+- Dsl.kt: verified-in-use — marked DSL wrapper with zero imports
+- ColorContext.kt: verified-in-use — ColorContext with zero imports
+- External.kt: verified-in-use — d3 color external wrapper

--- a/.github/weekly-cleanup/logs/2026-06-08-client-components.md
+++ b/.github/weekly-cleanup/logs/2026-06-08-client-components.md
@@ -1,0 +1,114 @@
+**GH Actions run:** https://github.com/robertfmurdock/Coupling/actions/runs/27156507882
+
+**Download raw JSONL:** `gh run download 27156507882 -n agent-stream-log`
+
+---
+
+## Turn 1
+
+## Turn 2
+
+Reading required context files.
+
+## Turn 3
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/ARCHITECTURE_CANONICAL.md
+
+## Turn 4
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/BOUNDARIES.md
+
+## Turn 5
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/PERSONA.md
+
+## Turn 6
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/WORK_CHECKLIST.md
+
+## Turn 7
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/generated/repo-index.md
+
+## Turn 8
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/GRADLE_PLAYBOOK.md
+
+## Turn 9
+
+Reading candidate list and cleanup history.
+
+## Turn 10
+
+- Read: /home/runner/work/Coupling/Coupling/build/weekly-cleanup/candidates.md
+
+## Turn 11
+
+- Read: /home/runner/work/Coupling/Coupling/.github/weekly-cleanup/cleanup-history.md
+
+## Turn 12
+
+Reading context files for deeper understanding.
+
+## Turn 13
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/context.json
+
+## Turn 14
+
+- Read: /home/runner/work/Coupling/Coupling/agents.d/context/generated/workflows.md
+
+## Turn 15
+
+Starting investigation. Three smallest candidates from the list, all under 200 bytes:
+
+1. `client/components/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/external/marked/Dsl.kt` (128 bytes)
+2. `client/components/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/ColorContext.kt` (140 bytes)
+3. `client/components/graphing/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/graphing/external/d3/color/External.kt` (146 bytes)
+
+Running TCR delete on first candidate:
+
+## Turn 16
+
+- Bash: agents.d/utilities/tcr-delete.sh "client/components/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/externa…
+
+## Turn 17
+
+Candidate 1 is verified in-use (deletion broke the build). Next candidate:
+
+## Turn 18
+
+- Bash: agents.d/utilities/tcr-delete.sh "client/components/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/ColorCo…
+
+## Turn 19
+
+Candidate 2 is verified in-use (references via context hooks, which don't show up in import scans). Next candidate:
+
+## Turn 20
+
+- Bash: agents.d/utilities/tcr-delete.sh "client/components/graphing/src/jsMain/kotlin/com/zegreatrob/coupling/client/component…
+
+## Turn 21
+
+All three smallest candidates are verified in-use. Pattern: the zero-import heuristic misses context-hook references and dynamic/reflection imports in Kotlin/JS. Evaluated 3 candidates with no safe deletion targets found.
+
+Writing cleanup history:
+
+## Turn 22
+
+- Read: /home/runner/work/Coupling/Coupling/.github/weekly-cleanup/cleanup-history.md
+
+## Turn 23
+
+History is complete. Evaluated 3 candidates in client/components, all verified in-use. No safe deletion targets found.
+
+**Summary:** All three smallest candidates tested:
+- `marked/Dsl.kt`: imports via DSL functions used without explicit imports
+- `ColorContext.kt`: referenced via React context hooks (undetectable by import scan)
+- `d3/color/External.kt`: re-exported by Heatmap
+
+The zero-import heuristic fails consistently for Kotlin/JS due to context hooks, DSL functions, and dynamic module resolution. No safe cleanup target found.
+
+## Result
+
+Outcome: **success**


### PR DESCRIPTION
## What Changed
- Weekly cleanup scoped to `client/components`.

## Cleanup History (recent)
```
- AreEqualPairs.kt: verified-in-use — pair equality functions

## 2026-05-17 (run-automated-cleanup-2) — libraries/model
- (no safe targets found) — zero-import candidate scan found no deletion candidates

## 2026-05-17 (run-claude-session-cleanup) — libraries/model

## 2026-05-18 (run-claude-session-cleanup) — libraries/model
- (no safe targets found) — prior runs exhaustively tested candidate functions; cross-references verified by grep
- (no safe targets found) — all model library utilities verified as multi-module consumers; prior runs thoroughly evaluated candidates

## 2026-05-18 (run-26009271530-boundary-scan) — libraries/model
- (no safe targets found) — boundary check: model exports only multi-module reusable contracts; no app-specific policy detected
- (no safe targets found) — libraries/action contains shared algorithms (Game, Round, Wheel) correctly placed; SDK dispatchers clean (no silent fallback patterns); test placement verified appropriate across boundary levels

## 2026-05-19 (run-26095510557-1) — libraries/model
- (no safe targets found) — prior runs exhaustively tested deletion candidates; scope sweep across sdk, server, client, coupling-plugins confirms no boundary violations; Gradle build logic clean

## 2026-05-25 (run-auto-cleanup) — libraries/repository/core
- (no safe targets found) — focus module contains only interface definitions and extension syntax; no test files (tested via integration in dynamo/compound modules); all public APIs verified in-use

## 2026-06-08 (run-27156507882-1) — client/components
- Dsl.kt: verified-in-use — marked DSL wrapper with zero imports
- ColorContext.kt: verified-in-use — ColorContext with zero imports
- External.kt: verified-in-use — d3 color external wrapper
```

## Architecture Alignment
- Constrained to one focus area in weekly rotation.
- Follows context contract from `agents.d/context/context.json` and canonical guidance files.

## Validation Commands and Results
- `./gradlew check` (pre-agent green verification + post-agent full validation)

## Risk and Rollback
- Risk: low-to-moderate; cleanup-only scope with hard safety gates.
- Rollback: revert this PR commit or close PR without merge.

<details><summary>Agent reasoning log</summary>

**GH Actions run:** https://github.com/robertfmurdock/Coupling/actions/runs/27156507882

**Download raw JSONL:** `gh run download 27156507882 -n agent-stream-log`

---

**Turn 2:**

Reading required context files.

**Turn 9:**

Reading candidate list and cleanup history.

**Turn 12:**

Reading context files for deeper understanding.

**Turn 15:**

Starting investigation. Three smallest candidates from the list, all under 200 bytes:

1. `client/components/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/external/marked/Dsl.kt` (128 bytes)
2. `client/components/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/ColorContext.kt` (140 bytes)
3. `client/components/graphing/src/jsMain/kotlin/com/zegreatrob/coupling/client/components/graphing/external/d3/color/External.kt` (146 bytes)

Running TCR delete on first candidate:

**Turn 17:**

Candidate 1 is verified in-use (deletion broke the build). Next candidate:

**Turn 19:**

Candidate 2 is verified in-use (references via context hooks, which don't show up in import scans). Next candidate:

**Turn 21:**

All three smallest candidates are verified in-use. Pattern: the zero-import heuristic misses context-hook references and dynamic/reflection imports in Kotlin/JS. Evaluated 3 candidates with no safe deletion targets found.

Writing cleanup history:

**Turn 23:**

History is complete. Evaluated 3 candidates in client/components, all verified in-use. No safe deletion targets found.

**Summary:** All three smallest candidates tested:
- `marked/Dsl.kt`: imports via DSL functions used without explicit imports
- `ColorContext.kt`: referenced via React context hooks (undetectable by import scan)
- `d3/color/External.kt`: re-exported by Heatmap

The zero-import heuristic fails consistently for Kotlin/JS due to context hooks, DSL functions, and dynamic module resolution. No safe cleanup target found.

**Result:** success

</details>